### PR TITLE
Change the arguments of syncDiff to the same as Sequelize constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,12 +55,12 @@ module.exports = function(Sequelize) {
           ssl: self.config.ssl
         };
         var dummyConfig = {
-          host: options.host,
-          port: options.port,
-          user: username,
-          password: password,
-          database: database,
-          ssl: options.ssl
+          host: sequelize.config.host,
+          port: sequelize.config.port,
+          user: sequelize.config.username,
+          password: sequelize.config.password,
+          database: sequelize.config.database,
+          ssl: sequelize.config.ssl
         };
         return new Promise(function (resolve, reject) {
           dbdiff.compareDatabases(masterConfig, dummyConfig, function(err) {

--- a/index.js
+++ b/index.js
@@ -27,9 +27,9 @@ module.exports = function(Sequelize) {
     }
   })
 
-  Sequelize.prototype.syncDiff = function(url, options) {
+  Sequelize.prototype.syncDiff = function(database, username, password, options) {
     var self = this
-    var sequelize = new Sequelize(url, options || this.options)
+    var sequelize = new Sequelize(database, username, password, options || this.options)
     this.diff_actions.forEach(function(action) {
       if (!action.model) {
         sequelize[action.method].apply(sequelize, action.args)

--- a/index.js
+++ b/index.js
@@ -49,21 +49,24 @@ module.exports = function(Sequelize) {
         dbdiff.logger = function(msg) {
           arr.push(msg)
         }
-        var selfURL = self.config.protocol+'://'
-        if (self.config.username && self.config.password) {
-          selfURL += self.config.username+':'+self.config.password+'@'
-        }
-        selfURL += self.config.host
-        if (self.config.port) {
-          selfURL += ':'+self.config.port
-        }
-        selfURL += '/'+self.config.database
-        if (self.options.dialectOptions && self.options.dialectOptions.ssl) {
-          selfURL += '?ssl=true'
-        }
-
+        var masterConfig = {
+          host: self.config.host,
+          port: self.config.port,
+          user: self.config.username,
+          password: self.config.password,
+          database: self.config.database,
+          ssl: self.config.ssl
+        };
+        var dummyConfig = {
+          host: options.host,
+          port: options.port,
+          user: username,
+          password: password,
+          database: database,
+          ssl: options.ssl
+        };
         return new Promise(function (resolve, reject) {
-          dbdiff.compareDatabases(selfURL, url, function(err) {
+          dbdiff.compareDatabases(masterConfig, dummyConfig, function(err) {
             err ? reject(err) : resolve(arr.join('\n'))
           })
         })

--- a/index.js
+++ b/index.js
@@ -40,10 +40,7 @@ module.exports = function(Sequelize) {
       }
     })
 
-    return self.sync()
-      .then(function() {
-        return sequelize.sync({ force: true })
-      })
+    return sequelize.sync({ force: true })
       .then(function() {
         var arr = []
         dbdiff.logger = function(msg) {


### PR DESCRIPTION
Using url affects compatibility as older versions of postgresql does not support.
Instead, passing config object should be more compatibility to other nodejs db clients, thus maybe helpful when dbdiff plan to support other database later on.

P.S. Sometimes is troublesome when database user password contain special characters, e.g. '@', '/'...
